### PR TITLE
Improve Windows build, startup reliability, and stream failure handling

### DIFF
--- a/FrontEnd/MainWindow.xaml.cs
+++ b/FrontEnd/MainWindow.xaml.cs
@@ -166,20 +166,23 @@ namespace MiSTerCast
                 if (isInitialized)
                 {
                     EnablePreviewCheckBox.IsChecked = false;
+                    string target = TargetIpAddresTextBox.Text.Trim();
                     IPAddress ipAddress = null;
-                    if (!IPAddress.TryParse(TargetIpAddresTextBox.Text, out ipAddress))
+                    bool targetWasHostname = !IPAddress.TryParse(target, out ipAddress);
+                    if (targetWasHostname)
                     {
                         try
                         {
-                            var hostEntry = Dns.GetHostEntry(TargetIpAddresTextBox.Text);
+                            var hostEntry = Dns.GetHostEntry(target);
                             if (hostEntry.AddressList == null || hostEntry.AddressList.Length == 0)
                             {
-                                Log("No IP addresses found for hostname: " + TargetIpAddresTextBox.Text, true);
+                                Log("No IP addresses found for hostname: " + target, true);
                                 return;
                             }
                             // Prefer IPv4 addresses
                             ipAddress = hostEntry.AddressList.FirstOrDefault(a => a.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
                                 ?? hostEntry.AddressList[0];
+                            Log("Resolved target " + target + " to " + ipAddress + ".");
                         }
                         catch (Exception exception)
                         {
@@ -194,6 +197,10 @@ namespace MiSTerCast
                         ToggleStreamButton.Content = "Stop Stream";
                         CaptureSourceBox.IsEnabled = false;
                         EnableAudioCheckBox.IsEnabled = false;
+                    }
+                    else if (targetWasHostname)
+                    {
+                        Log("Start stream failed for " + target + " (" + ipAddress + "). If multiple MiSTers share this hostname, use the target IP address.", true);
                     }
                 }
             }

--- a/FrontEnd/MainWindow.xaml.cs
+++ b/FrontEnd/MainWindow.xaml.cs
@@ -78,7 +78,8 @@ namespace MiSTerCast
             if (isStreaming)
                 MiSTerCastInterop.StopStream();
             MiSTerCastInterop.Shutdown();
-            helpWindow.Close();
+            if (helpWindow != null)
+                helpWindow.Close();
         }
 
         private void Window_Closed(object sender, EventArgs e)
@@ -170,7 +171,15 @@ namespace MiSTerCast
                     {
                         try
                         {
-                            ipAddress = Dns.GetHostEntry(TargetIpAddresTextBox.Text).AddressList[0];
+                            var hostEntry = Dns.GetHostEntry(TargetIpAddresTextBox.Text);
+                            if (hostEntry.AddressList == null || hostEntry.AddressList.Length == 0)
+                            {
+                                Log("No IP addresses found for hostname: " + TargetIpAddresTextBox.Text, true);
+                                return;
+                            }
+                            // Prefer IPv4 addresses
+                            ipAddress = hostEntry.AddressList.FirstOrDefault(a => a.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+                                ?? hostEntry.AddressList[0];
                         }
                         catch (Exception exception)
                         {
@@ -290,37 +299,57 @@ namespace MiSTerCast
 
         private void LoadSaveFileFromStream(StreamReader sr)
         {
-            int settingsVersion = int.Parse(sr.ReadLine());
-            if (settingsVersion > SettingsVersion)
+            try
             {
-                Log("Unsupported save file version: " + settingsVersion, true);
-                return;
+                int settingsVersion;
+                if (!int.TryParse(sr.ReadLine(), out settingsVersion))
+                {
+                    Log("Invalid settings file format.", true);
+                    return;
+                }
+                if (settingsVersion > SettingsVersion)
+                {
+                    Log("Unsupported save file version: " + settingsVersion, true);
+                    return;
+                }
+
+                TargetIpAddresTextBox.Text = sr.ReadLine() ?? "";
+
+                int modelineIndex;
+                if (int.TryParse(sr.ReadLine(), out modelineIndex))
+                    ModelinePresetsBox.SelectedIndex = Math.Min(modelineIndex, ModelinePresetsBox.Items.Count - 1);
+
+                pclockTextBox.Text = sr.ReadLine() ?? "";
+                hactiveTextBox.Text = sr.ReadLine() ?? "";
+                hbeginTextBox.Text = sr.ReadLine() ?? "";
+                hendTextBox.Text = sr.ReadLine() ?? "";
+                htotalTextBox.Text = sr.ReadLine() ?? "";
+                vactiveTextBox.Text = sr.ReadLine() ?? "";
+                vbeginTextBox.Text = sr.ReadLine() ?? "";
+                vendTextBox.Text = sr.ReadLine() ?? "";
+                vtotalTextBox.Text = sr.ReadLine() ?? "";
+                interlacedCheckBox.IsChecked = sr.ReadLine() == "1";
+
+                int captureIndex, rotateIndex, cropIndex;
+                if (int.TryParse(sr.ReadLine(), out captureIndex))
+                    CaptureSourceBox.SelectedIndex = Math.Min(captureIndex, CaptureSourceBox.Items.Count - 1);
+                if (int.TryParse(sr.ReadLine(), out rotateIndex))
+                    RotateComboBox.SelectedIndex = Math.Min(rotateIndex, RotateComboBox.Items.Count - 1);
+                EnableAudioCheckBox.IsChecked = sr.ReadLine() == "1";
+                if (int.TryParse(sr.ReadLine(), out cropIndex))
+                    CropComboBox.SelectedIndex = Math.Min(cropIndex, CropComboBox.Items.Count - 1);
+
+                CaptureWidth.Text = sr.ReadLine() ?? "";
+                CaptureHeight.Text = sr.ReadLine() ?? "";
+                CaptureXOffset.Text = sr.ReadLine() ?? "";
+                CaptureYOffset.Text = sr.ReadLine() ?? "";
+
+                Log("Settings loaded.");
             }
-
-            TargetIpAddresTextBox.Text = sr.ReadLine();
-
-            ModelinePresetsBox.SelectedIndex = Math.Min(int.Parse(sr.ReadLine()), ModelinePresetsBox.Items.Count - 1);
-            pclockTextBox.Text = sr.ReadLine();
-            hactiveTextBox.Text = sr.ReadLine();
-            hbeginTextBox.Text = sr.ReadLine();
-            hendTextBox.Text = sr.ReadLine();
-            htotalTextBox.Text = sr.ReadLine();
-            vactiveTextBox.Text = sr.ReadLine();
-            vbeginTextBox.Text = sr.ReadLine();
-            vendTextBox.Text = sr.ReadLine();
-            vtotalTextBox.Text = sr.ReadLine();
-            interlacedCheckBox.IsChecked = sr.ReadLine() == "1" ? true : false;
-
-            CaptureSourceBox.SelectedIndex = Math.Min(int.Parse(sr.ReadLine()), CaptureSourceBox.Items.Count - 1);
-            RotateComboBox.SelectedIndex = Math.Min(int.Parse(sr.ReadLine()), RotateComboBox.Items.Count - 1);
-            EnableAudioCheckBox.IsChecked = sr.ReadLine() == "1" ? true : false;
-            CropComboBox.SelectedIndex = Math.Min(int.Parse(sr.ReadLine()), CropComboBox.Items.Count - 1);
-            CaptureWidth.Text = sr.ReadLine();
-            CaptureHeight.Text = sr.ReadLine();
-            CaptureXOffset.Text = sr.ReadLine();
-            CaptureYOffset.Text = sr.ReadLine();
-
-            Log("Settings loaded.");
+            catch (Exception e)
+            {
+                Log("Error parsing settings file: " + e.Message, true);
+            }
         }
 
         private void UpdateLastSaveFile(string fileName)
@@ -374,6 +403,7 @@ namespace MiSTerCast
         #region Logs
 
         private MiSTerCastInterop.LogDelegate LogDelegate;
+        private const int MaxLogEntries = 1000;
 
         private void Log(string message, bool error = false)
         {
@@ -382,7 +412,11 @@ namespace MiSTerCast
                 TextBlock logText = new TextBlock() { Text = message };
                 if (error)
                     logText.Background = Brushes.Pink;
-                LogPanel.Children.Add(logText);//.Insert(0, (logText));
+                LogPanel.Children.Add(logText);
+
+                // Remove oldest entries when log exceeds maximum
+                while (LogPanel.Children.Count > MaxLogEntries)
+                    LogPanel.Children.RemoveAt(0);
             });
         }
 

--- a/FrontEnd/MiSTerCast.sln
+++ b/FrontEnd/MiSTerCast.sln
@@ -4,6 +4,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 15.0.28307.1705
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MiSTerCast", "MiSTerCast.csproj", "{9F56815A-0D3B-49AE-95DF-8A5124B2FF6B}"
+	ProjectSection(ProjectDependencies) = postProject
+		{3F2B9AA9-BCC6-475B-8B39-3562BFE8CEB7} = {3F2B9AA9-BCC6-475B-8B39-3562BFE8CEB7}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MiSTerCastLib", "..\Library\MiSTerCastLib\MiSTerCastLib.vcxproj", "{3F2B9AA9-BCC6-475B-8B39-3562BFE8CEB7}"
 EndProject

--- a/Library/MiSTerCastLib/AudioCapture.h
+++ b/Library/MiSTerCastLib/AudioCapture.h
@@ -19,6 +19,7 @@ IMMDevice *pDevice = NULL;
 IAudioClient *pAudioClient = NULL;
 IAudioCaptureClient *pCaptureClient = NULL;
 WAVEFORMATEX *pwfx = NULL;
+bool audioComInitialized = false;
 
 bool InitAudioCapture()
 {
@@ -26,6 +27,7 @@ bool InitAudioCapture()
 
     hr = CoInitialize(nullptr);
     EXIT_ON_ERROR(hr, "CoInitialize failed");
+    audioComInitialized = true;
 
     hr = CoCreateInstance(
         __uuidof(MMDeviceEnumerator), NULL,
@@ -63,13 +65,19 @@ bool InitAudioCapture()
     return true;
 }
 
-void CleanupAudioCatpure()
+void CleanupAudioCapture()
 {
     CoTaskMemFree(pwfx);
-    SAFE_RELEASE(pEnumerator)
-    SAFE_RELEASE(pDevice)
-    SAFE_RELEASE(pAudioClient)
-    SAFE_RELEASE(pCaptureClient)
+    pwfx = NULL;
+    SAFE_RELEASE(pEnumerator);
+    SAFE_RELEASE(pDevice);
+    SAFE_RELEASE(pAudioClient);
+    SAFE_RELEASE(pCaptureClient);
+    if (audioComInitialized)
+    {
+        CoUninitialize();
+        audioComInitialized = false;
+    }
 }
 
 bool StartAudioCapture()

--- a/Library/MiSTerCastLib/MiSTerCastLib.cpp
+++ b/Library/MiSTerCastLib/MiSTerCastLib.cpp
@@ -34,6 +34,21 @@ void capture_screen()
 }
 
 std::atomic_bool casting_screen = false;
+std::mutex castStartMutex;
+std::condition_variable castStartCondition;
+bool castStartReady = false;
+bool castStartSucceeded = false;
+
+void SignalCastStart(bool succeeded)
+{
+    {
+        std::lock_guard<std::mutex> lock(castStartMutex);
+        castStartSucceeded = succeeded;
+        castStartReady = true;
+    }
+    castStartCondition.notify_one();
+}
+
 void cast_screen()
 {
     if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST))
@@ -51,6 +66,22 @@ void cast_screen()
     casting_screen = true;
     {
         auto renderer = std::make_unique<renderer_nogpu>(targetIpString);
+        if (!renderer->initialize())
+        {
+            casting_screen = false;
+            SignalCastStart(false);
+            LogMessage("Casting to MiSTer stopped.");
+
+            if (source_config.audio)
+            {
+                StopAudioCapture();
+                LogMessage("Audio capture stopped.");
+            }
+
+            return;
+        }
+
+        SignalCastStart(true);
         {
             while (!stopStream)
             {
@@ -122,10 +153,13 @@ MISTERCASTLIB_API bool Initialize(log_function fnLog, capture_image_function fnC
 
 MISTERCASTLIB_API bool Shutdown()
 {
+    StopStream();
+
     stopCapture = true;
 
     if (captureScreenTask && captureScreenTask->joinable())
         captureScreenTask->join();
+    captureScreenTask.reset();
     stopCapture = false;
 
     CleanupVideoCapture();
@@ -141,7 +175,36 @@ MISTERCASTLIB_API bool StartStream(const char* targetIp)
 {
     LogMessage("Starting stream.");
     targetIpString = std::string(targetIp);
+
+    if (castScreenTask && castScreenTask->joinable())
+    {
+        LogMessage("Stream is already running.", true);
+        return false;
+    }
+
+    stopStream = false;
+    {
+        std::lock_guard<std::mutex> lock(castStartMutex);
+        castStartReady = false;
+        castStartSucceeded = false;
+    }
+
     castScreenTask = std::make_unique<std::thread>(cast_screen);
+
+    {
+        std::unique_lock<std::mutex> lock(castStartMutex);
+        castStartCondition.wait(lock, [] { return castStartReady; });
+    }
+
+    if (!castStartSucceeded)
+    {
+        stopStream = true;
+        if (castScreenTask && castScreenTask->joinable())
+            castScreenTask->join();
+        castScreenTask.reset();
+        stopStream = false;
+        return false;
+    }
 
     return true;
 }
@@ -152,6 +215,7 @@ MISTERCASTLIB_API bool StopStream()
 
     if (castScreenTask && castScreenTask->joinable())
         castScreenTask->join();
+    castScreenTask.reset();
     stopStream = false;
     return true;
 }

--- a/Library/MiSTerCastLib/MiSTerCastLib.cpp
+++ b/Library/MiSTerCastLib/MiSTerCastLib.cpp
@@ -25,10 +25,10 @@ void capture_screen()
 {
     LogMessage("Screen capture starting.");
     capturing_screen = true;
-    do
+    while (!stopCapture)
     {
         TickVideoCapture();
-    } while (!stopCapture);
+    }
     capturing_screen = false;
     LogMessage("Screen capture stopped.");
 }
@@ -52,10 +52,10 @@ void cast_screen()
     {
         auto renderer = std::make_unique<renderer_nogpu>(targetIpString);
         {
-            do
+            while (!stopStream)
             {
                 renderer->draw();
-            } while (!stopStream);
+            }
         }
     }
     casting_screen = false;
@@ -123,11 +123,15 @@ MISTERCASTLIB_API bool Initialize(log_function fnLog, capture_image_function fnC
 MISTERCASTLIB_API bool Shutdown()
 {
     stopCapture = true;
-    do {} while (capturing_screen); // wait for threads
+
+    if (captureScreenTask && captureScreenTask->joinable())
+        captureScreenTask->join();
     stopCapture = false;
 
-    captureScreenTask->detach();
+    CleanupVideoCapture();
+    CleanupAudioCapture();
 
+    initialized = false;
     return true;
 }
 
@@ -145,10 +149,10 @@ MISTERCASTLIB_API bool StartStream(const char* targetIp)
 MISTERCASTLIB_API bool StopStream()
 {
     stopStream = true;
-    do {} while (casting_screen); // wait for threads
-    stopStream = false;
 
-    castScreenTask->detach();
+    if (castScreenTask && castScreenTask->joinable())
+        castScreenTask->join();
+    stopStream = false;
     return true;
 }
 
@@ -233,10 +237,11 @@ MISTERCASTLIB_API bool SetSource(
     if (displayIndex != source_config.display)
     {
         stopCapture = true;
-        do {} while (capturing_screen); // wait for threads
+
+        if (captureScreenTask && captureScreenTask->joinable())
+            captureScreenTask->join();
         stopCapture = false;
 
-        captureScreenTask->detach();
         CleanupVideoCapture();
         InitializeVideoCapture(source_config.display, captureFunction);
         captureScreenTask = std::make_unique<std::thread>(capture_screen);

--- a/Library/MiSTerCastLib/VideoCapture.h
+++ b/Library/MiSTerCastLib/VideoCapture.h
@@ -94,17 +94,17 @@ bool InitializeVideoCapture(int outputNumber, capture_image_function fnCapture)
     hr = dxgiAdapter->EnumOutputs(displayIndex, &dxgiOutput);
     dxgiAdapter->Release();
     dxgiAdapter = nullptr;
-    EXIT_ON_ERROR(hr, "DxgiAdapter->EnumOutputs faile");
+    EXIT_ON_ERROR(hr, "DxgiAdapter->EnumOutputs failed");
 
     // DXGI_OUTPUT_DESC        outputDesc;
     // hr = dxgiOutput->GetDesc(&outputDesc);
-    // EXIT_ON_ERROR(hr, "DxgiOutput->GetDesc faile");
+    // EXIT_ON_ERROR(hr, "DxgiOutput->GetDesc failed");
 
     IDXGIOutput1* dxgiOutput1 = nullptr;
     hr = dxgiOutput->QueryInterface(__uuidof(dxgiOutput1), (void**)&dxgiOutput1);
     dxgiOutput->Release();
     dxgiOutput = nullptr;
-    EXIT_ON_ERROR(hr, "DxgiOutput->QueryInterface faile");
+    EXIT_ON_ERROR(hr, "DxgiOutput->QueryInterface failed");
 
     hr = dxgiOutput1->DuplicateOutput(d3dDevice, &desktopDuplication);
     dxgiOutput1->Release();
@@ -120,6 +120,12 @@ void CleanupVideoCapture()
     SAFE_RELEASE(d3dDeviceContext);
     SAFE_RELEASE(d3dDevice);
     haveFrameLock = false;
+
+    if (videoCaptures != nullptr)
+    {
+        delete[] videoCaptures;
+        videoCaptures = nullptr;
+    }
 }
 
 bool TickVideoCapture()
@@ -264,6 +270,7 @@ bool TickVideoCapture()
         break;
     case Alignment::Left:
         yoffset += desc.Height / 2 - height / 2;
+        break;
     default:
         break;
     }
@@ -315,8 +322,17 @@ bool TickVideoCapture()
         videoCaptures[nextIndex].buffer.resize(width * height * 4);
     }
 
-    for (int y = 0; y < (int)height; y++) // TODO: Can this be improved?
-        memcpy(videoCaptures[nextIndex].buffer.data() + y * width * 4, (uint8_t*)sr.pData + sr.RowPitch * y, width * 4);
+    // Optimize: single copy when row pitch matches expected stride
+    if (sr.RowPitch == width * 4)
+    {
+        memcpy(videoCaptures[nextIndex].buffer.data(), sr.pData, width * height * 4);
+    }
+    else
+    {
+        // Row-by-row copy when GPU texture has padding
+        for (unsigned int y = 0; y < height; y++)
+            memcpy(videoCaptures[nextIndex].buffer.data() + y * width * 4, (uint8_t*)sr.pData + sr.RowPitch * y, width * 4);
+    }
     d3dDeviceContext->Unmap(cpuTex, 0);
 
     if (currentSourceOptions.preview)

--- a/Library/MiSTerCastLib/groovymister.cpp
+++ b/Library/MiSTerCastLib/groovymister.cpp
@@ -505,7 +505,7 @@ void GroovyMister::CmdSwitchres(double pClock, uint16_t hActive, uint16_t hBegin
 		m_RGBSize = m_RGBSize >> 1;
 	}
 
-	m_widthTime = 10 * round((double) hTotal * (1 / pClock)); //in nanosec, time to raster 1 line
+	m_widthTime = static_cast<uint32_t>(10 * round((double) hTotal * (1 / pClock))); //in nanosec, time to raster 1 line
 	m_frameTime = (m_widthTime * vTotal) >> interlace_modeline;
 	
 	m_interlace = interlace_modeline;
@@ -545,7 +545,8 @@ void GroovyMister::CmdBlit(uint32_t frame, uint8_t field, uint16_t vCountSync, u
 		else
 		{
 			uint32_t timeCalc = (m_network_ping + margin + m_emulationTime >= m_frameTime) ? 0 : m_network_ping + margin + m_emulationTime - m_streamTime;
-			vSync = (timeCalc == 0) ? 1 : m_vTotal - round(m_vTotal * timeCalc) / m_frameTime;
+			uint32_t vSyncCalc = (timeCalc == 0) ? 1 : m_vTotal - static_cast<uint32_t>(round(m_vTotal * timeCalc) / m_frameTime);
+			vSync = static_cast<uint16_t>(vSyncCalc);
 		}
 	}
 
@@ -1060,7 +1061,7 @@ inline void GroovyMister::setTimeEnd(void)
 uint32_t GroovyMister::DiffTime(void)
 {
 #ifdef _WIN32
-	return m_tickEnd.QuadPart - m_tickStart.QuadPart;
+	return static_cast<uint32_t>(m_tickEnd.QuadPart - m_tickStart.QuadPart);
 #else
 	uint32_t diffTime = 0;
 	timespec temp;

--- a/Library/MiSTerCastLib/pch.h
+++ b/Library/MiSTerCastLib/pch.h
@@ -24,6 +24,8 @@
 #include <algorithm>
 #include <thread>
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 
 #include <MMDeviceAPI.h>
 #include <AudioClient.h>

--- a/Library/MiSTerCastLib/renderer_nogpu.h
+++ b/Library/MiSTerCastLib/renderer_nogpu.h
@@ -68,6 +68,7 @@ public:
 
     ~renderer_nogpu();
     int create();
+    bool initialize();
     void draw();
     void save() {}
     void record() {}
@@ -123,11 +124,37 @@ int renderer_nogpu::create()
 }
 
 //============================================================
+//  renderer_nogpu::initialize
+//============================================================
+
+bool renderer_nogpu::initialize()
+{
+    if (m_initialized)
+        return true;
+
+    m_initialized = nogpu_init();
+    if (m_initialized)
+    {
+        LogMessage("Done.");
+        nogpu_switch_video_mode();
+    }
+    else
+    {
+        m_first_blit = false;
+    }
+
+    return m_initialized;
+}
+
+//============================================================
 //  renderer_nogpu::~renderer_nogpu
 //============================================================
 
 renderer_nogpu::~renderer_nogpu()
 {
+    if (!m_initialized)
+        return;
+
     // Wait for fpga to flush last blit
     SleepTicks(uint64_t(m_period * time_sleep));
 
@@ -166,18 +193,7 @@ void renderer_nogpu::draw()
 
     // initialize nogpu right before first blit
     if (m_first_blit && !m_initialized)
-    {
-        m_initialized = nogpu_init();
-        if (m_initialized)
-        {
-            LogMessage("Done.");
-            nogpu_switch_video_mode();
-        }
-        else
-        {
-            m_first_blit = false;
-        }
-    }
+        initialize();
 
     // only send frame if nogpu is initialized
     if (!m_initialized)
@@ -355,22 +371,29 @@ bool renderer_nogpu::nogpu_init()
         LogMessage("Unsupported audio sample rate. Only 48kHz, 44.1kHz and 22.05kHz are supported.");
     }
 
-    LogMessage("Sending CMD_INIT...");
-
     // Reset current mode
     m_current_mode = {};
 
-    int ret = groovyMister.CmdInit(m_targetip.c_str(), UDP_PORT, m_compression, audioSampleRate, 2, 0, 1500);
-    if (ret == 0)
+    const int maxAttempts = 8;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++)
     {
-        audioBuffer = (uint16_t*)groovyMister.getPBufferAudio();
-        return true;
+        if (attempt == 1)
+            LogMessage("Sending CMD_INIT...");
+        else
+            LogMessage("Retrying CMD_INIT (" + std::to_string(attempt) + "/" + std::to_string(maxAttempts) + ")...");
+
+        int ret = groovyMister.CmdInit(m_targetip.c_str(), UDP_PORT, m_compression, audioSampleRate, 2, 0, 1500);
+        if (ret == 0)
+        {
+            audioBuffer = (uint16_t*)groovyMister.getPBufferAudio();
+            return true;
+        }
+
+        Sleep(250);
     }
-    else
-    {
-        LogMessage("Groovy MiSTer API failed to initialize!");
-        return false;
-    }
+
+    LogMessage("Groovy MiSTer API failed to initialize. No UDP ACK from target.", true);
+    return false;
 }
 
 //============================================================

--- a/Library/MiSTerCastLib/renderer_nogpu.h
+++ b/Library/MiSTerCastLib/renderer_nogpu.h
@@ -185,8 +185,8 @@ void renderer_nogpu::draw()
 
     m_frame++;
 
-    if (groovyMister.fpga.frame > m_frame)
-        m_frame = groovyMister.fpga.frame + 1;
+    if (groovyMister.fpga.frame > static_cast<uint32_t>(m_frame))
+        m_frame = static_cast<int>(groovyMister.fpga.frame + 1);
 
     // get current field for interlaced mode
     if (m_current_mode.interlace)
@@ -211,6 +211,7 @@ void renderer_nogpu::draw()
         stepx = ((float)(screenwidth) / (float)m_height);
         stepy = ((float)(screenheight) / (float)m_width);
         interlaceStepX = int(stepx / 2.0f);
+        break;
     case Rotation::CCW90:
         stepx = ((float)(screenwidth) / (float)m_height);
         stepy = ((float)(screenheight) / (float)m_width);
@@ -222,6 +223,7 @@ void renderer_nogpu::draw()
         stepy = ((float)(screenheight) / (float)m_height);
         interlaceStepY = int(stepy / 2.0f);
         drawInt = !drawInt;
+        break;
     default:
         stepx = ((float)(screenwidth) / (float)m_width);
         stepy = ((float)(screenheight) / (float)m_height);
@@ -230,6 +232,9 @@ void renderer_nogpu::draw()
     }
 
     char* fb = groovyMister.getPBufferBlit(m_field);
+    if (!fb)
+        return;
+
     for (unsigned int i = 0; i < (pitch * m_height * 4); i += 4)
     {
         int x = (i / 4) % m_width;
@@ -259,10 +264,12 @@ void renderer_nogpu::draw()
             bmpy += interlaceStepY;
         }
         int bmpi = (bmpy * screenwidth + bmpx) * 4;
-        if (bmpi + 4 >= (screenheight * screenwidth * 4))
+        const int sourceBufferSize = screenheight * screenwidth * 4;
+        if (bmpi < 0 || bmpi + 2 >= sourceBufferSize)
             continue;
+        if (j + 2 >= BUFFER_SIZE)
+            break;
 
-        
         fb[j] =     (char)videoCaptures[drawIndex].buffer[bmpi];
         fb[j + 1] = (char)videoCaptures[drawIndex].buffer[bmpi + 1];
         fb[j + 2] = (char)videoCaptures[drawIndex].buffer[bmpi + 2];
@@ -331,8 +338,6 @@ void renderer_nogpu::draw()
 
 bool renderer_nogpu::nogpu_init()
 {
-    int result;
-
     m_compression = 0x01; // lz4 compression
 
     switch (audioSampleRate)
@@ -374,32 +379,28 @@ bool renderer_nogpu::nogpu_init()
 
 bool renderer_nogpu::nogpu_switch_video_mode()
 {
-    nogpu_modeline *mode = &selected_modeline;
-    if (mode == nullptr)
-        return false;
-
-    m_current_mode = *mode;
+    m_current_mode = selected_modeline;
 
     // Send new modeline to nogpu
     LogMessage("Sending CMD_SWITCHRES...");
 
-    m_width = mode->hactive;
-    m_height = mode->vactive;
-    m_vtotal = mode->vtotal;
+    m_width = selected_modeline.hactive;
+    m_height = selected_modeline.vactive;
+    m_vtotal = selected_modeline.vtotal;
     m_field = 0;
 
     shouldUpdateVideoMode = false;
     groovyMister.CmdSwitchres(
-        mode->pclock,
-        mode->hactive,
-        mode->hbegin,
-        mode->hend,
-        mode->htotal,
-        mode->vactive,
-        mode->vbegin,
-        mode->vend,
-        mode->vtotal,
-        mode->interlace
+        selected_modeline.pclock,
+        selected_modeline.hactive,
+        selected_modeline.hbegin,
+        selected_modeline.hend,
+        selected_modeline.htotal,
+        selected_modeline.vactive,
+        selected_modeline.vbegin,
+        selected_modeline.vend,
+        selected_modeline.vtotal,
+        selected_modeline.interlace
     );
 
     return true;
@@ -425,7 +426,7 @@ void renderer_nogpu::nogpu_register_frametime(uint64_t frametime)
     time_frame[i] = frametime;
     i++;
 
-    if (i > max_regs)
+    if (i >= max_regs)
         i = 0;
 
     if (regs < max_regs)
@@ -439,7 +440,7 @@ void renderer_nogpu::nogpu_register_frametime(uint64_t frametime)
     // Compute current max deviation
     uint64_t max_diff = 0;
 
-    for (int k = 1; k <= regs; k++)
+    for (int k = 1; k < regs; k++)
     {
         diff = time_frame[k] - time_frame[k - 1];
 

--- a/Library/MiSTerCastLib/rio.h
+++ b/Library/MiSTerCastLib/rio.h
@@ -6,9 +6,15 @@ using std::endl;
 //mingw missing headers
 //#if defined(_WIN32) && !defined(WSA_FLAG_REGISTERED_IO)
 #if defined(_WIN32)
+#ifndef WSA_FLAG_REGISTERED_IO
 #define WSA_FLAG_REGISTERED_IO 0x100
+#endif
+#ifndef SIO_GET_MULTIPLE_EXTENSION_FUNCTION_POINTER
 #define SIO_GET_MULTIPLE_EXTENSION_FUNCTION_POINTER _WSAIORW(IOC_WS2, 36)
+#endif
+#ifndef WSAID_MULTIPLE_RIO
 #define WSAID_MULTIPLE_RIO {0x8509e081, 0x96dd, 0x4005, { 0xb1, 0x65, 0x9e, 0x2e, 0xe8, 0xc7, 0x9e, 0x3f } }
+#endif
 
 /* Windows SDK actually have these definitions :
    * typedef struct RIO_BUFFERID_t *RIO_BUFFERID, **PRIO_BUFFERID;

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,110 @@
+param(
+    [string]$Configuration = "Debug",
+    [string]$Platform = "Any CPU",
+    [string]$PlatformToolset = "v143",
+    [switch]$Clean
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Solution = Join-Path $RepoRoot "FrontEnd\MiSTerCast.sln"
+$Lz4Dir = Join-Path $RepoRoot "External\lz4"
+$Lz4Header = Join-Path $Lz4Dir "include\lz4.h"
+
+function Get-MSBuildPath {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path -LiteralPath $vswhere) {
+        $found = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -find "MSBuild\Current\Bin\amd64\MSBuild.exe" | Select-Object -First 1
+        if ($found) {
+            return $found
+        }
+    }
+
+    $fromPath = (Get-Command MSBuild.exe -ErrorAction SilentlyContinue | Select-Object -First 1).Source
+    if ($fromPath) {
+        return $fromPath
+    }
+
+    throw "MSBuild.exe not found. Install Visual Studio Build Tools with MSBuild."
+}
+
+function Get-TargetFrameworkVersion {
+    $frameworkRoot = Join-Path ${env:ProgramFiles(x86)} "Reference Assemblies\Microsoft\Framework\.NETFramework"
+    foreach ($version in @("v4.6.1", "v4.8.1", "v4.8")) {
+        if (Test-Path -LiteralPath (Join-Path $frameworkRoot $version)) {
+            return $version
+        }
+    }
+
+    throw ".NET Framework targeting pack not found. Install v4.6.1 or v4.8+ targeting packs."
+}
+
+function Get-WindowsSdkVersion {
+    $sdkRoot = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\Include"
+    $preferred = "10.0.22621.0"
+    if (Test-Path -LiteralPath (Join-Path $sdkRoot $preferred)) {
+        return $preferred
+    }
+
+    $latest = Get-ChildItem -LiteralPath $sdkRoot -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+        Sort-Object { [version]$_.Name } -Descending |
+        Select-Object -First 1
+
+    if ($latest) {
+        return $latest.Name
+    }
+
+    throw "Windows 10 SDK headers not found."
+}
+
+function Ensure-Lz4 {
+    if (Test-Path -LiteralPath $Lz4Header) {
+        return
+    }
+
+    Write-Host "Downloading LZ4 1.9.4..."
+    $zip = Join-Path $env:TEMP "lz4_win32_v1_9_4.zip"
+    Invoke-WebRequest -Uri "https://github.com/lz4/lz4/releases/download/v1.9.4/lz4_win32_v1_9_4.zip" -OutFile $zip
+
+    if (Test-Path -LiteralPath $Lz4Dir) {
+        $resolved = (Resolve-Path -LiteralPath $Lz4Dir).Path
+        if (-not $resolved.StartsWith($RepoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Refusing to remove LZ4 directory outside repo: $resolved"
+        }
+        Remove-Item -LiteralPath $resolved -Recurse -Force
+    }
+
+    New-Item -ItemType Directory -Path $Lz4Dir | Out-Null
+    Expand-Archive -LiteralPath $zip -DestinationPath $Lz4Dir -Force
+}
+
+$msbuild = Get-MSBuildPath
+$targetFramework = Get-TargetFrameworkVersion
+$windowsSdk = Get-WindowsSdkVersion
+Ensure-Lz4
+
+$commonArgs = @(
+    $Solution,
+    "/p:Configuration=$Configuration",
+    "/p:Platform=$Platform",
+    "/p:PlatformToolset=$PlatformToolset",
+    "/p:WindowsTargetPlatformVersion=$windowsSdk",
+    "/p:TargetFrameworkVersion=$targetFramework"
+)
+
+Write-Host "MSBuild: $msbuild"
+Write-Host "Framework: $targetFramework"
+Write-Host "Windows SDK: $windowsSdk"
+Write-Host "Toolset: $PlatformToolset"
+
+if ($Clean) {
+    & $msbuild @commonArgs /t:Clean
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+
+& $msbuild @commonArgs
+exit $LASTEXITCODE


### PR DESCRIPTION
1. Repo-local Windows build path
- Adds build.ps1 so contributors can build without opening Visual Studio.
- Locates MSBuild, Windows SDK, .NET Framework targeting pack, and LZ4 paths.
- Adds the native library as an explicit solution dependency for correct build order.
2. Frontend startup/settings hardening
- Prevents shutdown crashes when the help window was never opened.
- Resolves hostnames defensively and prefers IPv4 addresses.
- Handles malformed settings values without throwing.
- Caps log growth so the UI does not accumulate unbounded log entries.
3. Native capture shutdown cleanup
- Joins capture/stream threads instead of spinning or detaching.
- Cleans up video/audio capture resources during shutdown and source changes.
- Releases COM audio resources correctly.
- Fixes capture alignment fallthrough and row-pitch copy handling.
4. Renderer and timing hardening
- Adds renderer bounds checks and null frame-buffer handling.
- Fixes missing switch breaks in rotation/interlace handling.
- Fixes frametime ring-buffer bounds.
- Removes native build warnings from RIO macro redefinition and narrowing conversions.
5. Failed Groovy stream startup handling
- Waits for Groovy CMD_INIT before marking the stream as started.
- Retries CMD_INIT briefly before reporting failure.
- Cleans up failed stream startup without requiring Stop Stream.
- Avoids sending CMD_CLOSE when Groovy never initialized.
- Logs resolved hostname targets so duplicate MiSTer hostnames are visible.